### PR TITLE
improve Error for correct exception wrapping

### DIFF
--- a/lib/yetis_node/error.rb
+++ b/lib/yetis_node/error.rb
@@ -1,4 +1,11 @@
 module YetisNode
   class Error < RuntimeError
+    attr_reader :original
+
+    def initialize(msg, original=$!)
+      super(msg)
+      @original = original
+    end
+
   end
 end


### PR DESCRIPTION
Allow to get to initial exception after re raising.
copy pasted from http://devblog.avdi.org/2013/12/25/exception-causes-in-ruby-2-1/
