### PR TITLE
do not destroy json_rpc client in JsonRpcTransport after request

### DIFF
--- a/lib/yetis_node/client.rb
+++ b/lib/yetis_node/client.rb
@@ -9,7 +9,7 @@ module YetisNode
   class Client
     extend Forwardable
 
-    attr_reader :uri, :options
+    attr_reader :uri, :options, :transport
 
     def_delegators :@transport, :rpc_send
 

--- a/lib/yetis_node/json_rpc_transport.rb
+++ b/lib/yetis_node/json_rpc_transport.rb
@@ -3,18 +3,18 @@ module YetisNode
   class JsonRpcTransport < BaseTransport
 
     def rpc_send(*args)
-      jrpc = json_rpc
       begin
-        jrpc.invoke_request(*args)
+        json_rpc.connect if json_rpc.closed?
+        result = json_rpc.invoke_request(*args)
+        json_rpc.close
+        result
       rescue ::JRPC::Error => e
         raise Error.new("JSON RPC Error: #{"(#{e.code}) " if e.respond_to?(:code)}#{e.message}")
-      ensure
-        jrpc.close
       end
     end
 
     def json_rpc
-      ::JRPC::TcpClient.new uri,
+      @json_rpc ||= ::JRPC::TcpClient.new uri,
                             namespace: 'yeti.',
                             timeout: options.fetch(:timeout, BaseTransport::DEFAULT_TIMEOUT)
     end

--- a/yetis_node.gemspec
+++ b/yetis_node.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'jrpc', '>= 0.4.3'
+  spec.add_dependency 'jrpc', '>= 0.4.6'
 
   spec.add_development_dependency 'bundler', '~> 1.7'
   spec.add_development_dependency 'rake', '~> 10.0'


### PR DESCRIPTION
without this PR we have no access to json rpc client.
for example we need to get some debug information during development
with this PR we can do it like:

``` ruby
logger = Logger.new($stdout).tap { |l| l.progname = 'yetisnode' }
logger.level = Logger::DEBUG
client = YetisNode::Client.new(uri, transport: :json_rpc)
client.transport.json_rpc.logger = logger
response = client.system_status
puts JSON.pretty_generate(response)
```
