### PR TITLE
WIP: json_rpc_transport rpc_send method second argumtn not mandatory

### DIFF
--- a/lib/yetis_node/json_rpc_transport.rb
+++ b/lib/yetis_node/json_rpc_transport.rb
@@ -3,7 +3,7 @@ require 'jrpc'
 module YetisNode
   class JsonRpcTransport < BaseTransport
 
-    def rpc_send(method_name, params)
+    def rpc_send(method_name, params = [])
       begin
         json_rpc.connect if json_rpc.closed?
         result = json_rpc.perform_request(method_name, params: params)


### PR DESCRIPTION
Small fix for usability of `rpc_send` method. Second argument not mandatory